### PR TITLE
Incremental install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Beware of possible breaking changes in the future, if you seek stability, obtain
 
 ### Options:
 
-    --verbose         [-v] Print progress log messages
-    --repo            Git URL to repository with node_modules content  [required]
-    --cross-platform  Run in cross-platform mode
+    --verbose               [-v] Print progress log messages
+    --repo                  Git URL to repository with node_modules content  [required]
+    --cross-platform        Run in cross-platform mode
+    --incremental-install   Keep previous modules instead of always performing a fresh npm install
 
 
 ## Why you need it
@@ -64,8 +65,8 @@ The algorithm is simple:
 1. Check if node_modules folder is present in the working directory  
 2. If node_modules exists check if there is a separate git repository in it  
 3. Calculate sha1 hash from package.json in base64 format  
-4. If remote repo from [2] has a commit tagged with sha1 from [3] then check it out clean, no npm install is required  
-5. Otherwise remove everything from node_modules, do a clean npm install, commit, tag with sha1 from [3] and push to remote repo  
+4. If remote repo from [2] has a commit tagged with sha1 from [3] then check it out clean, no `npm install` is required
+5. Otherwise remove everything from node_modules (unless `--incremental-install` is set, in which case only uncommitted changes will be stashed away), do a clean `npm install`, commit, tag with sha1 from [3] and push to remote repo
 6. Next time you build with the same package.json, it is guaranteed that you get node_modules from the first run  
 
 After this you end up with a reliable and reproducible source controlled node_modules folder.      
@@ -84,6 +85,22 @@ Inspired by [this post](https://medium.com/@g_syner/for-the-most-part-i-really-l
 4. Run `git status --untracked-files=all` to list all files that have been generated in the previous step. Add these files to `.gitignore`.
 
 `--cross-platform` is only supported on `npm` version >= 3, since npm 2 doesn't run custom install scripts as it should during `npm rebuild` (cf. [this CI failure](https://circleci.com/gh/bestander/npm-git-lock/11)).
+
+### Incremental installs
+
+By default, `npm-git-lock` will perform a completely fresh `npm install` whenever there is any change to package.json (i.e., there is no commit in the node_modules repository tagged with the sha1 of package.json). However, that might not always be desired, since all dependencies might change (as long as their version is still within the range specified in package.json).
+
+To get a behavior more similar to `npm shrinkwrap`, you can use the option `--incremental-install`. When installing modules, it will reuse modules that have already been committed to the node_modules repository and only run `npm install` "on top of them".
+
+A potential caveat is that modules are always fetched from the latest state (the master branch) of the node_modules repository. If there are dependencies introduced in a previous commit but not on the latest master HEAD, they will be freshly installed.
+
+*Example*: In your project, you work on a branch *A* that declares a new dependency *depA* in package.json. In parallel, you have a branch *B* declaring a new dependency *depB*. Then you merge them both back into master. Assuming you run `npm-git-lock` in each step, the history of your central node_modules repository will look like this (from recent to older):
+
+ * [commit3, master HEAD] *depA* + *depB*
+ * [commit2] *depB*
+ * [commit1] *depA*
+
+Note that when running `npm-git-lock` after the merge (to produce commit3), only *depB* was fetched from the previous state. For *depA*, a fresh install was performed.
 
 
 ## Amazing features  

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Beware of possible breaking changes in the future, if you seek stability, obtain
 
     --verbose               [-v] Print progress log messages
     --repo                  Git URL to repository with node_modules content  [required]
-    --cross-platform        Run in cross-platform mode
-    --incremental-install   Keep previous modules instead of always performing a fresh npm install
+    --cross-platform        Run in cross-platform mode (npm 3 only)
+    --incremental-install   Keep previous modules instead of always performing a fresh npm install (npm 3 only)
+
+`npm-git-lock` works with both npm 2 and 3, although the options `--cross-platform` and `--incremental-install` are only supported on npm 3.
 
 
 ## Why you need it

--- a/README.md
+++ b/README.md
@@ -105,17 +105,18 @@ Note that when running `npm-git-lock` after the merge (to produce commit3), only
 
 ## Amazing features  
 
-With this package you get:  
-1. Minimum dependency on npm servers availability for repeated builds which is very common for CI systems  
-2. No noise in your main project Pull Requests, all packages are committed to a separate git repository that does not need to be reviewed or maintained  
-3. If the separate git repository for packages gets too large and slows down your builds after a few years, you can just create a new one, saving the old one for patches if you need  
-4. Using it does not interfere with the recommended npm workflow, you can use it only on your CI system with no side effects for your dev environment or mix it with shrinkwrapping  
+With this package you get:
+
+1. Minimum dependency on npm servers availability for repeated builds which is very common for CI systems.
+2. No noise in your main project Pull Requests, all packages are committed to a separate git repository that does not need to be reviewed or maintained.
+3. If the separate git repository for packages gets too large and slows down your builds after a few years, you can just create a new one, saving the old one for patches if you need.
+4. Using it does not interfere with the recommended npm workflow, you can use it only on your CI system with no side effects for your dev environment or mix it with shrinkwrapping.
 5. You can have different node_modules repositories for different OS. Your CI is likely to be linux while your dev machines may be mac or windows. You can set up 3 repositories for them and use them independently.  
-6. And it is blazing fast  
+6. And it is blazing fast.
 
 ## Troubleshoot
 
-If you see this kind of error in your CI.  
+If you see this kind of error in your CI: 
 
 ```
 Cloning into 'node_modules'...
@@ -135,7 +136,7 @@ Just add those two commands before `npm-git-lock` call.
 ## Contribution
 
 Please give me your feedback and send Pull Requests.  
-Unit tests rely on `require(`child_process`).execSync` command that works in node 0.11+.  
+Unit tests rely on ```require(`child_process`).execSync``` command that works in node 0.11+.  
 
 ## License MIT
 

--- a/cli.js
+++ b/cli.js
@@ -6,12 +6,18 @@ var argv = require('optimist')
 .describe('verbose', '[-v] Print progress log messages')
 .describe('repo', 'git url to repository with node_modules content')
 .describe('cross-platform', 'do not archive platform-specific files in node_modules')
+.describe('incremental-install', 'start npm install with last node_modules instead of clearing them')
 .alias('v', 'verbose')
 .demand(['repo']).argv;
 
 var checkoutNodeModules = require('./lib/checkout-node-modules');
 
-checkoutNodeModules(process.cwd(), {repo: argv.repo, verbose: argv.verbose, crossPlatform: argv['cross-platform']})
+checkoutNodeModules(process.cwd(), {
+    verbose: argv.verbose,
+    repo: argv.repo,
+    crossPlatform: argv['cross-platform'],
+    incrementalInstall: argv['incremental-install']
+})
 .then(function () {
     process.exit(0);
 })

--- a/src/checkout-node-modules.es6
+++ b/src/checkout-node-modules.es6
@@ -299,6 +299,9 @@ module.exports = (cwd, {repo, verbose, crossPlatform, incrementalInstall}) => {
         .then(() => {
             log.debug(`Adding tag`);
             return git(`tag ${packageJsonSha1}`)
+            .catch(() => {
+                // Ignore errors while tagging (it's not a problem if the tag already exists)
+            })
             .then(() => {
                 log.debug(`Pushing tag ${packageJsonSha1} to ${repo}`);
                 return git(`push ${repo} master --tags`);

--- a/src/checkout-node-modules.es6
+++ b/src/checkout-node-modules.es6
@@ -212,13 +212,13 @@ module.exports = (cwd, {repo, verbose, crossPlatform}) => {
         log.debug(`Requested tag does not exist, removing everything from node_modules and running 'npm install'`);
         log.debug(`(This might take a few minutes. Please be patient!)`);
         process.chdir(`${cwd}/node_modules`);
-        return git(`checkout master`)
+        // Stash any local changes before switching to master.
+        // This doesn't seem very elegant... Maybe we should rather hard-reset master to origin/master.
+        // This just seems a little "safer".
+        // We should also think about what happens if origin/master diverges between here and the actual push.
+        return git(`stash save --include-untracked`)
         .then(() => {
-            // Stash any local changes before pulling.
-            // This doesn't seem very elegant... Maybe we should rather hard-reset master to origin/master.
-            // This just seems a little "safer".
-            // We should also think about what happens if origin/master diverges between here and the actual push.
-            return git(`stash`);
+            return git(`checkout master`);
         })
         .then(() => {
             // Pull first so that the push later does not (or at least is much less likely to)

--- a/src/checkout-node-modules.es6
+++ b/src/checkout-node-modules.es6
@@ -115,7 +115,7 @@ module.exports = (cwd, {repo, verbose, crossPlatform}) => {
         .then(() => {
             log.debug(`cloning ${repo}`);
             return git(`clone ${repo} node_modules`);
-        })
+        });
     }
 
     function git(cmd, {silent}={}) {
@@ -205,7 +205,7 @@ module.exports = (cwd, {repo, verbose, crossPlatform}) => {
             ignored = uniq(ignored);
             fs.writeFileSync('.gitignore', ignored.join('\n'), {encoding: 'utf8'});
             return git(`add .gitignore`);
-        })
+        });
     }
 
     function installPackagesTagAndPushToRemote() {
@@ -258,7 +258,7 @@ module.exports = (cwd, {repo, verbose, crossPlatform}) => {
         .then(() => {
             log.debug(`Pushing tag ${packageJsonSha1} to ${repo}`);
             return git(`push ${repo} master --tags`);
-        })
+        });
     }
 };
 

--- a/test/checkout-node-modules.spec.es6
+++ b/test/checkout-node-modules.spec.es6
@@ -291,10 +291,10 @@ describe(`npm-git-lock`, function() {
         let checkoutNodeModules = rewire("../src/checkout-node-modules");
         checkoutNodeModules.__set__('crypto', {
             createHash: () => {
-                console.log("CREATE HASH")
+                console.log("CREATE HASH");
                 return {
                     update: () => {
-                        console.log("CALLED UPDATE")
+                        console.log("CALLED UPDATE");
                         return {
                             digest: () => fakeHash
                         };

--- a/test/checkout-node-modules.spec.es6
+++ b/test/checkout-node-modules.spec.es6
@@ -341,7 +341,7 @@ describe(`npm-git-lock`, function() {
         .then(done, done);
     });
 
-    it(`should not perform a fresh install when --incremental-install is set`, (done) => {
+    npm3 && it(`should not perform a fresh install when --incremental-install is set`, (done) => {
 
         function writeFakeModule(version) {
             let moduleJson = stringify({


### PR DESCRIPTION
Added an option `--incremental-install` to keep existing node_modules (only stashing away uncommitted changes) before running `npm install`. Also a few other minor improvements.
