### PR TITLE
Remove dash from --loglevel arg so that it is recognized properly by npm

### DIFF
--- a/src/checkout-node-modules.es6
+++ b/src/checkout-node-modules.es6
@@ -165,7 +165,7 @@ module.exports = (cwd, {repo, verbose, crossPlatform, incrementalInstall}) => {
     }
 
     function npmRunCommands(npmCommand, listOfArgs, {silent}={}) {
-        let logLevel = [`--log-level=${verbose ? 'warn' : 'silent'}`];
+        let logLevel = [`--loglevel=${verbose ? 'warn' : 'silent'}`];
         return new Promise((resolve, reject) => {
             let output = [];
             listOfArgs.every((args) => {


### PR DESCRIPTION
The loglevel command line arg for npm should be --loglevel, not --log-level (the dash should be removed).

https://docs.npmjs.com/misc/config
