### PR TITLE
Add ES6 String.prototype.startsWith polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lodash": "^3.10.1",
     "loglevel": "^1.2.0",
     "optimist": "^0.6.1",
-    "shelljs": "^0.5.3"
+    "shelljs": "^0.5.3",
+    "string.prototype.startswith": "^0.2.0"
   },
   "devDependencies": {
     "babel": "^4.7.16",

--- a/src/checkout-node-modules.es6
+++ b/src/checkout-node-modules.es6
@@ -13,7 +13,7 @@ let stringify = require(`json-stable-stringify`);
 let uniq = require(`lodash/array/uniq`);
 
 require('es6-promise').polyfill();
-require('string.prototype.startsWith');
+require('string.prototype.startswith');
 
 let readFilePromise = promisify(fs.readFile);
 let delPromise = promisify(del);

--- a/src/checkout-node-modules.es6
+++ b/src/checkout-node-modules.es6
@@ -13,6 +13,7 @@ let stringify = require(`json-stable-stringify`);
 let uniq = require(`lodash/array/uniq`);
 
 require('es6-promise').polyfill();
+require('string.prototype.startsWith');
 
 let readFilePromise = promisify(fs.readFile);
 let delPromise = promisify(del);


### PR DESCRIPTION
Older JS engines, such as the one with Node v0.12.2, throw an exception that .startsWith is undefined. Including this polyfill fixes the problem.

I opted to include this minimal polyfill instead of the full babel-polyfill in an attempt to keep in line with the minimalist style of this project.

This is a follow-up to the failed PR #23 
