### PR TITLE
Add option (check-all-json-elements) for back compatible

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,6 +8,7 @@ var argv = require('optimist')
 .describe('cross-platform', 'do not archive platform-specific files in node_modules')
 .describe('incremental-install', 'start npm install with last node_modules instead of clearing them')
 .describe('production', 'start npm install with production flag')
+.describe('check-all-json-elements', 'Sha-1 calculated from all elements in package.json instead of only dependencies and devDependencies')
 .alias('v', 'verbose')
 .demand(['repo']).argv;
 
@@ -18,7 +19,8 @@ checkoutNodeModules(process.cwd(), {
     repo: argv.repo,
     crossPlatform: argv['cross-platform'],
     incrementalInstall: argv['incremental-install'],
-    production: argv['production']
+    production: argv['production'],
+    checkAllJsonElements: argv['check-all-json-elements']
 })
 .then(function () {
     process.exit(0);

--- a/src/checkout-node-modules.es6
+++ b/src/checkout-node-modules.es6
@@ -37,7 +37,7 @@ const PLATFORM_SPECIFIC_MODULES = {
  */
 const MAX_SHELL_LENGTH = 2000;
 
-module.exports = (cwd, {repo, verbose, crossPlatform, incrementalInstall, production}) => {
+module.exports = (cwd, {repo, verbose, crossPlatform, incrementalInstall, production, checkAllJsonElements}) => {
 
     let packageJsonSha1;
     let packageJsonVersion;
@@ -47,9 +47,17 @@ module.exports = (cwd, {repo, verbose, crossPlatform, incrementalInstall, produc
     return readFilePromise(`${cwd}/package.json`, `utf-8`)
     .then((packageJsonContent) => {
         let packageJson = JSON.parse(packageJsonContent);
+        let stableContent;
         // compute a hash based on the stable-stringified contents of package.json
         // (`packageJsonContent` might differ on different platforms, depending on line endings etc.)
-        let stableContent = stringify([packageJson.dependencies, packageJson.devDependencies]);
+        if (checkAllJsonElements) {
+          log.debug(`Sha-1 calculated from all elements in package.json.`);
+          stableContent = stringify(packageJson);
+        } else {
+          log.debug(`Sha-1 calculated from dependencies and devDependencies in package.json.`);
+          stableContent = stringify([packageJson.dependencies, packageJson.devDependencies]);
+        }
+
         // replace / in hash with _ because git does not allow leading / in tags
         packageJsonSha1 = crypto.createHash(`sha1`).update(stableContent).digest(`base64`).replace(/\//g, "_");
         packageJsonVersion = packageJson.version;
@@ -347,7 +355,3 @@ module.exports = (cwd, {repo, verbose, crossPlatform, incrementalInstall, produc
         });
     }
 };
-
-
-
-

--- a/test/checkout-node-modules.spec.es6
+++ b/test/checkout-node-modules.spec.es6
@@ -295,6 +295,83 @@ describe(`npm-git-lock`, function() {
         .then(() => done(), done);
     });
 
+    it(`(back compatible) should not do an npm install if remote repo master branch already has a tag with package.json hash`, function(done) {
+
+        process.chdir(`${cwd}/test/${testProjectFolder}`);
+        const packageJson = {
+            name: 'my-project',
+            version: '2.0.0',
+            dependencies: {
+                'fake-module': 'file:../fixtures/fake-module',
+            },
+            devDependencies: {
+            },
+            author: 'Konstantin Raev',
+            license: 'MIT',
+        };
+        fs.writeFileSync(`package.json`, JSON.stringify(packageJson));
+        // just add a tag to master branch then no npm innstallation is necessary
+        process.chdir(`${cwd}/test/${nodeModulesRemoteRepo}`);
+
+        const packageJsonSha1 = require(`crypto`).createHash(`sha1`).update(stringify(packageJson)).digest(`base64`);
+
+        execSync(`git tag ${packageJsonSha1}`);
+
+        require(`../src/checkout-node-modules`)(`${cwd}/test/${testProjectFolder}`, {
+            repo: `${cwd}/test/${nodeModulesRemoteRepo}`,
+            verbose: true,
+            checkAllJsonElements: true
+        })
+        .then(() => {
+            // there is the same tag in project`s node_modules
+            process.chdir(`${cwd}/test/${testProjectFolder}/node_modules`);
+            return git(`git describe --tags`);
+        })
+        .then((tag) => {
+            // current tag in node_modules repo is package.json hash
+            expect(packageJsonSha1).to.equal(tag.trim());
+        })
+        .then(() => {
+            // we don`t expect npm install was called
+            expect(fs.readdirSync(`${cwd}/test/${testProjectFolder}/node_modules`)).not.to.contain(`fake-module`);
+        })
+        .then(() => done(), done);
+    });
+
+    npm3 && it(`(back compatible) should not rebuild platform-specific modules if node_modules is already at the right commit`, function(done) {
+
+        process.chdir(`${cwd}/test/${testProjectFolder}`);
+        let packageJson = stringify({
+            "name": "my-project",
+            "version": "2.0.0",
+            "dependencies": {
+                "fake-platform-specific-module": "file:../fixtures/fake-platform-specific-module"
+            },
+            "devDependencies": {
+            },
+            "author": "Jan Poeschko",
+            "license": "MIT"
+        });
+        fs.writeFileSync(`package.json`, packageJson);
+        let checkout = require(`../src/checkout-node-modules`);
+        return checkout(`${cwd}/test/${testProjectFolder}`, {
+            repo: `${cwd}/test/${nodeModulesRemoteRepo}`, verbose: true, crossPlatform: true, checkAllJsonElements: true
+        })
+        .then(() => {
+            // delete the platform specific file
+            execSync(`rm ${cwd}/test/${testProjectFolder}/node_modules/fake-platform-specific-module/some-platform-specific-file`);
+            // do the same install another time
+            return checkout(`${cwd}/test/${testProjectFolder}`, {
+                repo: `${cwd}/test/${nodeModulesRemoteRepo}`, verbose: true, crossPlatform: true, checkAllJsonElements: true
+            })
+        })
+        .then(() => {
+            // we don't expect a rebuild, i.e. the platform-specific file is still not there
+            expect(fs.readdirSync(`${cwd}/test/${testProjectFolder}/node_modules/fake-platform-specific-module`)).not.to.contain(`some-platform-specific-file`);
+        })
+        .then(() => done(), done);
+    });
+
     it(`should replace / in package json hash with _`, function(done) {
 
         let fakeHash = "/1g8hUui8sC2JtwIkvw/GmyQYsA=";


### PR DESCRIPTION
If check-all-json-elements no set (default behavior):
 Sha-1 calculated from dependencies and devDependencies in package.json

If check-all-json-elements is set:
 Sha-1 calculated from full text of package.json. Which is back compatible with v3.3.0 and before.
